### PR TITLE
Show time stamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,10 +78,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "ctrlc"
@@ -111,6 +158,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -171,6 +250,7 @@ version = "0.6.2-alpha.1"
 dependencies = [
  "anyhow",
  "argsplitter",
+ "chrono",
  "ctrlc",
  "diff",
  "etherparse",
@@ -213,6 +293,15 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -363,6 +452,69 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.4",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ oob = []
 [dependencies]
 anyhow = "1.0.80"
 argsplitter = "0.5.0"
+chrono = "0.4.37"
 ctrlc = "3.4.2"
 etherparse = "0.14.2"
 is-terminal = "0.4.12"

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,8 @@
-use std::{error::Error, fmt, io};
+use std::{
+    error::Error,
+    fmt, io,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use smallvec::SmallVec;
 
@@ -259,5 +263,16 @@ impl<'a> ConnectionSink<'a> {
     pub fn emit_oob_received(&mut self, direction: Direction, byte: u8) {
         self.0
             .emit_event(MapiEvent::Oob(self.id(), direction, byte))
+    }
+}
+
+/// A timestamp represented as a [Duration] since the
+/// [UNIX_EPOCH][std::time::UNIX_EPOCH].
+pub struct Timestamp(pub Duration);
+
+impl From<SystemTime> for Timestamp {
+    fn from(t: SystemTime) -> Self {
+        let duration = t.duration_since(UNIX_EPOCH).unwrap();
+        Timestamp(duration)
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -268,6 +268,7 @@ impl<'a> ConnectionSink<'a> {
 
 /// A timestamp represented as a [Duration] since the
 /// [UNIX_EPOCH][std::time::UNIX_EPOCH].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Timestamp(pub Duration);
 
 impl From<SystemTime> for Timestamp {

--- a/src/mapi/mod.rs
+++ b/src/mapi/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::{
-    event::{ConnectionId, Direction, MapiEvent},
+    event::{ConnectionId, Direction, MapiEvent, Timestamp},
     render::{Renderer, Style},
     Level,
 };
@@ -29,7 +29,12 @@ impl State {
         }
     }
 
-    pub fn handle(&mut self, event: &MapiEvent, renderer: &mut Renderer) -> io::Result<()> {
+    pub fn handle(
+        &mut self,
+        _timestamp: &Timestamp,
+        event: &MapiEvent,
+        renderer: &mut Renderer,
+    ) -> io::Result<()> {
         match event {
             MapiEvent::BoundPort(port) => {
                 renderer.message(None, None, format_args!("LISTEN on port {port}"))?;

--- a/src/mapi/mod.rs
+++ b/src/mapi/mod.rs
@@ -31,10 +31,11 @@ impl State {
 
     pub fn handle(
         &mut self,
-        _timestamp: &Timestamp,
+        timestamp: &Timestamp,
         event: &MapiEvent,
         renderer: &mut Renderer,
     ) -> io::Result<()> {
+        renderer.set_timestamp(timestamp);
         match event {
             MapiEvent::BoundPort(port) => {
                 renderer.message(None, None, format_args!("LISTEN on port {port}"))?;

--- a/src/pcap/tracker.rs
+++ b/src/pcap/tracker.rs
@@ -3,19 +3,22 @@ use std::{io, net::IpAddr};
 use anyhow::{bail, Result as AResult};
 use etherparse::{InternetSlice, IpNumber, Ipv4Slice, Ipv6Slice, SlicedPacket, TcpSlice};
 
-use crate::event::MapiEvent;
+use crate::event::{MapiEvent, Timestamp};
 
 use super::tcp::TcpTracker;
 
 /// Struct Tracker holds the state necessary to process packets and emit MapiEvents.
 pub struct Tracker<'a> {
-    handler: Box<dyn FnMut(MapiEvent) -> io::Result<()> + 'a>,
+    #[allow(clippy::type_complexity)]
+    handler: Box<dyn for<'t> FnMut(&'t Timestamp, MapiEvent) -> io::Result<()> + 'a>,
     tcp_tracker: TcpTracker,
 }
 
 impl<'a> Tracker<'a> {
     /// Create a new Tracker which calls the given closure for each MapiEvent it needs to emit.
-    pub fn new(event_handler: impl FnMut(MapiEvent) -> io::Result<()> + 'a) -> Self {
+    pub fn new(
+        event_handler: impl for<'t> FnMut(&'t Timestamp, MapiEvent) -> io::Result<()> + 'a,
+    ) -> Self {
         let handler = Box::new(event_handler);
         Tracker {
             handler,
@@ -24,17 +27,17 @@ impl<'a> Tracker<'a> {
     }
 
     /// Process the given packet as an Ethernet frame.
-    pub fn process_ethernet(&mut self, data: &[u8]) -> AResult<()> {
+    pub fn process_ethernet(&mut self, timestamp: &Timestamp, data: &[u8]) -> AResult<()> {
         let ether_slice = SlicedPacket::from_ethernet(data)?;
         match &ether_slice.net {
-            Some(InternetSlice::Ipv4(inet4)) => self.handle_ipv4(inet4),
-            Some(InternetSlice::Ipv6(inet6)) => self.handle_ipv6(inet6),
+            Some(InternetSlice::Ipv4(inet4)) => self.handle_ipv4(timestamp, inet4),
+            Some(InternetSlice::Ipv6(inet6)) => self.handle_ipv6(timestamp, inet6),
             None => Ok(()),
         }
     }
 
     /// Examine IPv6 packet. If it's a TCP packet and not fragmented, hand it to [Self::handle_tcp]
-    pub fn handle_ipv6(&mut self, ipv6: &Ipv6Slice) -> AResult<()> {
+    pub fn handle_ipv6(&mut self, timestamp: &Timestamp, ipv6: &Ipv6Slice) -> AResult<()> {
         if ipv6.is_payload_fragmented() {
             bail!("pcap file contains fragmented ipv6 packet, not supported");
         }
@@ -50,11 +53,11 @@ impl<'a> Tracker<'a> {
         let header = &ipv6.header();
         let src = IpAddr::from(header.source_addr());
         let dest = IpAddr::from(header.destination_addr());
-        self.handle_tcp(src, dest, &tcp)
+        self.handle_tcp(timestamp, src, dest, &tcp)
     }
 
     /// Examine IPv4 packet. If it's a TCP packet and not fragmented, hand it to [Self::handle_tcp]
-    pub fn handle_ipv4(&mut self, ipv4: &Ipv4Slice) -> AResult<()> {
+    pub fn handle_ipv4(&mut self, timestamp: &Timestamp, ipv4: &Ipv4Slice) -> AResult<()> {
         if ipv4.is_payload_fragmented() {
             bail!("pcap file contains fragmented ipv4 packet, not supported");
         }
@@ -70,14 +73,21 @@ impl<'a> Tracker<'a> {
         let header = &ipv4.header();
         let src = IpAddr::from(header.source_addr());
         let dest = IpAddr::from(header.destination_addr());
-        self.handle_tcp(src, dest, &tcp)
+        self.handle_tcp(timestamp, src, dest, &tcp)
     }
 
     /// Called by [Self::handle_ipv4] and [Self::handle_ipv6] when they encounter TCP traffic
-    pub fn handle_tcp(&mut self, src: IpAddr, dest: IpAddr, tcp: &TcpSlice) -> AResult<()> {
+    pub fn handle_tcp(
+        &mut self,
+        timestamp: &Timestamp,
+        src: IpAddr,
+        dest: IpAddr,
+        tcp: &TcpSlice,
+    ) -> AResult<()> {
         // It's nice for handle_ipv4 and handle_ipv6 to simply call handle_tcp, but it turns
         // out that the actual handling is done by the [TcpTracker] subobject.
-        self.tcp_tracker.handle(src, dest, tcp, &mut self.handler)?;
+        self.tcp_tracker
+            .handle(timestamp, src, dest, tcp, &mut self.handler)?;
         Ok(())
     }
 }


### PR DESCRIPTION
It is useful to have an indication of when certain events happened.

It may give too much clutter to print a timestamp on each and every message. Experimentation is needed.